### PR TITLE
Fix time dropdown visibility issue

### DIFF
--- a/src/components/employee/EmployeeSchedule.tsx
+++ b/src/components/employee/EmployeeSchedule.tsx
@@ -240,10 +240,10 @@ export const EmployeeSchedule = () => {
                       onValueChange={(value) => updateSchedule(index, 'start_time', value)}
                     >
                       <SelectTrigger>
-                        <SelectValue />
+                        <SelectValue placeholder="Seleccionar hora de inicio" />
                       </SelectTrigger>
                       <SelectContent>
-                        {TIME_OPTIONS.filter(time => time < schedule.end_time).map((time) => (
+                        {TIME_OPTIONS.filter(time => time < schedule.end_time || time === schedule.start_time).map((time) => (
                           <SelectItem key={time} value={time}>
                             {time}
                           </SelectItem>
@@ -259,10 +259,10 @@ export const EmployeeSchedule = () => {
                       onValueChange={(value) => updateSchedule(index, 'end_time', value)}
                     >
                       <SelectTrigger>
-                        <SelectValue />
+                        <SelectValue placeholder="Seleccionar hora de fin" />
                       </SelectTrigger>
                       <SelectContent>
-                        {TIME_OPTIONS.filter(time => time > schedule.start_time).map((time) => (
+                        {TIME_OPTIONS.filter(time => time > schedule.start_time || time === schedule.end_time).map((time) => (
                           <SelectItem key={time} value={time}>
                             {time}
                           </SelectItem>


### PR DESCRIPTION
Fix time dropdowns not displaying selected values in 'Configurar Disponibilidad Semanal' by adding placeholders and adjusting filtering logic.

The issue stemmed from two factors: missing `placeholder` props on Radix UI `SelectValue` components, which prevented the display of selected values, and filtering logic that inadvertently excluded the *currently selected* time from the available options, leading to blank dropdowns despite saved data.