### PR TITLE
Fix service card data and navigation

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -69,12 +69,16 @@ const Index = () => {
   useEffect(() => {
     if (!loading && user) {
       navigate('/dashboard');
-    } else if (!loading && !user) {
+    }
+  }, [user, loading, navigate]);
+
+  useEffect(() => {
+    if (!loading) {
       fetchActiveCombos();
       fetchActiveServices();
       fetchActiveDiscounts();
     }
-  }, [user, loading, navigate]);
+  }, [loading]);
 
   const fetchActiveCombos = async () => {
     try {
@@ -118,18 +122,20 @@ const Index = () => {
     try {
       const { data, error } = await supabase
         .from("services")
-        .select("id, name, description, duration_minutes, price_cents, image_url, discount_percentage, original_price_cents")
+        .select("*")
         .eq("is_active", true)
         .limit(12);
       
       if (error) {
         console.error("Supabase error fetching services:", error);
+        setFetchError("Error loading services");
         return;
       }
       
       setServices(data || []);
     } catch (error) {
       console.error("Error fetching services:", error);
+      setFetchError("Error loading services");
     }
   };
 


### PR DESCRIPTION
Separate service fetching logic in Index page to ensure services load for all users.

Previously, service data was only fetched for non-authenticated users, preventing logged-in users from seeing the service cards. This PR moves the service fetching into a dedicated `useEffect` that runs regardless of user authentication status. It also improves error handling and simplifies the Supabase service query.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-7cb8f139-0cc9-4ffd-92fb-088ffc36e100) · [Cursor](https://cursor.com/background-agent?bcId=bc-7cb8f139-0cc9-4ffd-92fb-088ffc36e100)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)