### PR TITLE
Enable universal service card expansion and fix missing features

### DIFF
--- a/src/components/cards/BaseCard.tsx
+++ b/src/components/cards/BaseCard.tsx
@@ -51,7 +51,15 @@ export const BaseCard = ({
             ? 'h-28 sm:h-32' // Smaller height on mobile
             : 'h-32'
       } ${className}`}
-      onClick={!showExpandable ? onSelect : undefined}
+      onClick={(e) => {
+        if (!showExpandable) {
+          onSelect?.();
+          return;
+        }
+        if (!isExpanded) {
+          onExpandChange?.(true);
+        }
+      }}
     >
       {/* Background Image */}
       <div className="absolute inset-0">

--- a/src/components/dashboard/DashboardSummary.tsx
+++ b/src/components/dashboard/DashboardSummary.tsx
@@ -305,10 +305,10 @@ export const DashboardSummary = ({
             name: cs.services.name,
             quantity: cs.quantity,
             service_id: cs.service_id
-          })) || []} variant="dashboard" onSelect={() => navigate(`/book?service=${combo.id}&step=2`)} showExpandable={false} />)}
+          })) || []} variant="dashboard" onSelect={() => navigate(`/book?service=${combo.id}&step=2`)} showExpandable={true} />)}
               
               {/* Display Individual Discounts */}
-              {activePromotions.map(promo => <ServiceCard key={`discount-${promo.id}`} id={promo.services.id} name={promo.services.name} description={promo.services.description} originalPrice={promo.services.price_cents} finalPrice={promo.services.price_cents - (promo.discount_type === 'percentage' ? promo.services.price_cents * promo.discount_value / 100 : promo.discount_value * 100)} savings={promo.discount_type === 'percentage' ? promo.services.price_cents * promo.discount_value / 100 : promo.discount_value * 100} duration={promo.services.duration_minutes} imageUrl={promo.services.image_url} type="service" discountType={promo.discount_type} discountValue={promo.discount_value} variant="dashboard" onSelect={() => navigate(`/book?service=${promo.services.id}&step=2`)} showExpandable={false} />)}
+              {activePromotions.map(promo => <ServiceCard key={`discount-${promo.id}`} id={promo.services.id} name={promo.services.name} description={promo.services.description} originalPrice={promo.services.price_cents} finalPrice={promo.services.price_cents - (promo.discount_type === 'percentage' ? promo.services.price_cents * promo.discount_value / 100 : promo.discount_value * 100)} savings={promo.discount_type === 'percentage' ? promo.services.price_cents * promo.discount_value / 100 : promo.discount_value * 100} duration={promo.services.duration_minutes} imageUrl={promo.services.image_url} type="service" discountType={promo.discount_type} discountValue={promo.discount_value} variant="dashboard" onSelect={() => navigate(`/book?service=${promo.services.id}&step=2`)} showExpandable={true} />)}
             </div> : <div className="text-center py-8 text-muted-foreground">
               <div className="p-4 rounded-full bg-muted/30 w-16 h-16 mx-auto flex items-center justify-center mb-4">
                 <Sparkles className="h-8 w-8 text-muted-foreground" />


### PR DESCRIPTION
Enable service cards to expand on any card click and add expand/collapse to dashboard promotions, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-9259e97c-3b97-4d3a-99c6-43a2e3833bfd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9259e97c-3b97-4d3a-99c6-43a2e3833bfd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

