### PR TITLE
Add edit and delete buttons to service cards

### DIFF
--- a/src/components/admin/AdminServices.tsx
+++ b/src/components/admin/AdminServices.tsx
@@ -1435,6 +1435,51 @@ export const AdminServices = () => {
                 variant="admin"
                 showExpandable={true}
                 className="relative"
+                adminBadges={
+                  <>
+                    <Badge 
+                      variant={service.is_active ? "default" : "secondary"} 
+                      className={`text-xs font-medium shadow-lg ${
+                        service.is_active 
+                          ? 'bg-green-600 text-white border border-green-500' 
+                          : 'bg-gray-600 text-white border border-gray-500'
+                      }`}
+                    >
+                      {service.is_active ? "Activo" : "Inactivo"}
+                    </Badge>
+                    {service.service_categories?.name && (
+                      <Badge variant="outline" className="text-xs bg-white/80 text-gray-800 border-gray-300">
+                        {service.service_categories.name}
+                      </Badge>
+                    )}
+                  </>
+                }
+                adminButtons={
+                  <>
+                    <Button 
+                      variant="secondary" 
+                      size="sm" 
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleEdit(service);
+                      }}
+                      className="h-8 w-8 p-0 bg-white shadow-lg hover:bg-gray-50 border border-gray-200"
+                    >
+                      <Pencil className="h-3 w-3 text-gray-700" />
+                    </Button>
+                    <Button 
+                      variant="destructive" 
+                      size="sm" 
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(service.id);
+                      }}
+                      className="h-8 w-8 p-0 bg-red-600 hover:bg-red-700 shadow-lg border border-red-500"
+                    >
+                      <Trash2 className="h-3 w-3 text-white" />
+                    </Button>
+                  </>
+                }
               />
             </div>
           );


### PR DESCRIPTION
Add Edit and Delete admin buttons and status/category badges to service cards in the Servicios admin dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-855431f7-3a4a-4baf-80d7-fe07baf660d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-855431f7-3a4a-4baf-80d7-fe07baf660d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

