### PR TITLE
Fix time slot fetching for service bookings

### DIFF
--- a/src/components/booking/UnifiedBookingSystem.tsx
+++ b/src/components/booking/UnifiedBookingSystem.tsx
@@ -121,6 +121,29 @@ export const UnifiedBookingSystem = ({ config, selectedCustomer }: UnifiedBookin
     }
   };
 
+  // Fetch available time slots when service/date/employee changes
+  useEffect(() => {
+    const loadSlots = async () => {
+      if (!state.selectedService || !state.selectedDate) {
+        setAvailableSlots([]);
+        return;
+      }
+      setSlotsLoading(true);
+      try {
+        const slots = await fetchAvailableSlots(
+          state.selectedService,
+          state.selectedDate,
+          state.selectedEmployee
+        );
+        setAvailableSlots(slots);
+      } finally {
+        setSlotsLoading(false);
+      }
+    };
+
+    loadSlots();
+  }, [state.selectedService, state.selectedDate, state.selectedEmployee, fetchAvailableSlots]);
+
   // Render step content based on current step
   const renderStepContent = () => {
     switch (state.currentStep) {


### PR DESCRIPTION
Add `useEffect` to fetch available time slots in `UnifiedBookingSystem` to resolve missing availability.

Previously, the component lacked the necessary trigger to fetch available time slots when the service, date, or employee selection changed, leading to an empty availability grid.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ca72cee-8f89-4bc2-9335-798e43fc812b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ca72cee-8f89-4bc2-9335-798e43fc812b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

